### PR TITLE
Require Node utilities

### DIFF
--- a/lib/expectations/args.js
+++ b/lib/expectations/args.js
@@ -10,7 +10,8 @@
  *
  * @type {Function}
  */
-var Expectation = require('../expectation');
+var util = require('util')
+  , Expectation = require('../expectation');
 
 /**
  * Args constructor.


### PR DESCRIPTION
I'm seeing an error being raised in my test cases which is as follows:

```
      at Args.end (/Users/james/Projects/peapod/node_modules/jack/lib/expectations/args.js:65:19)
      at /Users/james/Projects/peapod/node_modules/jack/lib/stub.js:59:21
```

This patch should resolve the issue.
